### PR TITLE
Remove MUI dependency from icons and bump to 3.0.0

### DIFF
--- a/output/package-lock.json
+++ b/output/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@growthx-club/icons",
-  "version": "1.0.56",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@growthx-club/icons",
-      "version": "1.0.56",
+      "version": "3.0.0",
       "license": "ISC",
       "devDependencies": {
         "@types/react": "^18.2.67"

--- a/output/package-lock.json
+++ b/output/package-lock.json
@@ -12,387 +12,37 @@
         "@types/react": "^18.2.67"
       },
       "peerDependencies": {
-        "@mui/material": "^5.15.12 || ^6.4.11",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
-      "peer": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
-      "peer": true,
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1",
-        "@emotion/weak-memoize": "^0.3.1",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "peer": true
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==",
-      "peer": true
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==",
-      "peer": true
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==",
-      "peer": true
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
-      "peer": true
-    },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.38.tgz",
-      "integrity": "sha512-AsjD6Y1X5A1qndxz8xCcR8LDqv31aiwlgWMPxFAX/kCKiIGKlK65yMeVZ62iQr/6LBz+9hSKLiD1i4TZdAHKcQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.12",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.15.12",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.12.tgz",
-      "integrity": "sha512-brRO+tMFLpGyjEYHrX97bzqeF6jZmKpqqe1rY0LyIHAwP6xRVzh++zSecOQorDOCaZJg4XkGT9xfD+RWOWxZBA==",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "5.15.12",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.12.tgz",
-      "integrity": "sha512-vXJGg6KNKucsvbW6l7w9zafnpOp0CWc0Wx4mDykuABTpQ5QQBnZxP7+oB4yAS1hDZQ1WobbeIl0CjxK4EEahkA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/base": "5.0.0-beta.38",
-        "@mui/core-downloads-tracker": "^5.15.12",
-        "@mui/system": "^5.15.12",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.12",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "5.15.12",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.12.tgz",
-      "integrity": "sha512-cqoSo9sgA5HE+8vZClbLrq9EkyOnYysooepi5eKaKvJ41lReT2c5wOZAeDDM1+xknrMDos+0mT2zr3sZmUiRRA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.15.12",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "5.15.11",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.11.tgz",
-      "integrity": "sha512-So21AhAngqo07ces4S/JpX5UaMU2RHXpEA6hNzI6IQjd/1usMPxpgK8wkGgTe3JKmC2KDmH8cvoycq5H3Ii7/w==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "5.15.12",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.12.tgz",
-      "integrity": "sha512-/pq+GO6yN3X7r3hAwFTrzkAh7K1bTF5r8IzS79B9eyKJg7v6B/t4/zZYMR6OT9qEPtwf6rYN2Utg1e6Z7F1OgQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.15.12",
-        "@mui/styled-engine": "^5.15.11",
-        "@mui/types": "^7.2.13",
-        "@mui/utils": "^5.15.12",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/types": {
-      "version": "7.2.13",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.13.tgz",
-      "integrity": "sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils": {
-      "version": "5.15.12",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.12.tgz",
-      "integrity": "sha512-8SDGCnO2DY9Yy+5bGzu00NZowSDtuyHP4H8gunhHGQoIlhlY2Z3w64wBzAOLpYw/ZhJNzksDTnS/i8qdJvxuow==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@types/prop-types": "^15.7.11",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.67",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.67.tgz",
       "integrity": "sha512-vkIE2vTIMHQ/xL0rgmuoECBCkZFZeHr49HeWSc24AptMbNRo7pwSBvj73rlJJs9fGKj0koS+V7kQB1jHS0uCgw==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
-    },
-    "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "dev": true
     },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -412,32 +62,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
-    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -449,62 +73,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "peer": true
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "peer": true
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "peer": true
     }
   }
 }

--- a/output/package.json
+++ b/output/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthx-club/icons",
-  "version": "1.0.56",
+  "version": "3.0.0",
   "description": "Package for storing all the icons used across the GrowthX Platform",
   "repository": {
     "url": "git+https://github.com/GrowthX-Club/icons.git"

--- a/output/package.json
+++ b/output/package.json
@@ -14,7 +14,6 @@
     "@growthx-club:registry": "https://npm.pkg.github.com"
   },
   "peerDependencies": {
-    "@mui/material": "^5.15.12 || ^6.4.11 || ^7.0.0",
     "react": "^18.2.0 || ^19.0.0"
   },
   "exports": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GrowthX-Club/icons"
   },
   "scripts": {
-    "convert-svg": "svgr src --out-dir output/src --typescript --jsx-runtime automatic --template template.cjs --index-template index-template.cjs --expand-props none --no-dimensions",
+    "convert-svg": "svgr src --out-dir output/src --typescript --jsx-runtime automatic --template template.cjs --index-template index-template.cjs --expand-props none --no-dimensions --prettier-config '{\"parser\":\"typescript\"}'",
     "build": "vite build"
   },
   "keywords": [

--- a/template.cjs
+++ b/template.cjs
@@ -1,49 +1,66 @@
+const babelTemplate = require('@babel/template').smart;
 const {
   identifier,
+  jsxAttribute,
   jsxClosingElement,
   jsxElement,
+  jsxExpressionContainer,
   jsxIdentifier,
   jsxOpeningElement,
   jsxSpreadAttribute,
-  arrayExpression,
-  jsxAttribute,
-  jsxExpressionContainer,
   objectExpression,
   objectProperty,
+  spreadElement,
   stringLiteral,
 } = require('@babel/types');
+
 const template = (
-  { imports, interfaces, componentName, props, jsx, exports },
+  { imports, interfaces, componentName, jsx, exports },
   { tpl }
 ) => {
+  const astTpl = babelTemplate({
+    plugins: ['jsx', 'typescript'],
+    preserveComments: true,
+    syntacticPlaceholders: false,
+  }).ast;
   const wrappedJsx = jsxElement(
-    jsxOpeningElement(jsxIdentifier('Box'), [
+    jsxOpeningElement(jsxIdentifier('div'), [
       jsxSpreadAttribute(identifier('props')),
       jsxAttribute(
-        jsxIdentifier('sx'),
+        jsxIdentifier('style'),
         jsxExpressionContainer(
-          arrayExpression([
-            objectExpression([
-              objectProperty(identifier('width'), stringLiteral('38px')),
-              objectProperty(identifier('height'), stringLiteral('38px')),
-            ]),
-            identifier('...Array.isArray(props?.sx) ? props?.sx : [props?.sx]'),
+          objectExpression([
+            objectProperty(identifier('display'), stringLiteral('block')),
+            objectProperty(identifier('width'), stringLiteral('38px')),
+            objectProperty(identifier('height'), stringLiteral('38px')),
+            spreadElement(identifier('s')),
+            spreadElement(identifier('style')),
           ])
         )
       ),
     ]),
-    jsxClosingElement(jsxIdentifier('Box')),
+    jsxClosingElement(jsxIdentifier('div')),
     [jsx],
     false
   );
 
-  return tpl`${imports}
-import { Box, BoxProps } from '@mui/material';
-interface Props extends BoxProps {}
+  return astTpl`${imports}
+import type { CSSProperties, HTMLAttributes } from 'react';
+
+type IconCSSProperties = CSSProperties &
+  Record<\`--\${string}\`, string | number | undefined>;
+type SxValue = IconCSSProperties | null | undefined | false;
+type SxProp = SxValue | SxValue[];
+
+interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'style'> {
+  sx?: SxProp;
+  style?: IconCSSProperties;
+}
 
 ${interfaces}
 
-function ${componentName}(props: Props) {
+function ${componentName}({ sx, style, ...props }: Props) {
+  const s = Array.isArray(sx) ? Object.assign({}, ...sx.filter(Boolean)) : (sx ?? {});
   return ${wrappedJsx};
 }
 

--- a/template.cjs
+++ b/template.cjs
@@ -8,6 +8,7 @@ const {
   jsxIdentifier,
   jsxOpeningElement,
   jsxSpreadAttribute,
+  logicalExpression,
   objectExpression,
   objectProperty,
   spreadElement,
@@ -31,8 +32,14 @@ const template = (
         jsxExpressionContainer(
           objectExpression([
             objectProperty(identifier('display'), stringLiteral('block')),
-            objectProperty(identifier('width'), stringLiteral('38px')),
-            objectProperty(identifier('height'), stringLiteral('38px')),
+            objectProperty(
+              identifier('width'),
+              logicalExpression('??', identifier('width'), stringLiteral('38px'))
+            ),
+            objectProperty(
+              identifier('height'),
+              logicalExpression('??', identifier('height'), stringLiteral('38px'))
+            ),
             spreadElement(identifier('s')),
             spreadElement(identifier('style')),
           ])
@@ -51,15 +58,18 @@ type IconCSSProperties = CSSProperties &
   Record<\`--\${string}\`, string | number | undefined>;
 type SxValue = IconCSSProperties | null | undefined | false;
 type SxProp = SxValue | SxValue[];
+type IconSize = CSSProperties['width'];
 
 interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'style'> {
   sx?: SxProp;
   style?: IconCSSProperties;
+  width?: IconSize;
+  height?: IconSize;
 }
 
 ${interfaces}
 
-function ${componentName}({ sx, style, ...props }: Props) {
+function ${componentName}({ sx, style, width, height, ...props }: Props) {
   const s = Array.isArray(sx) ? Object.assign({}, ...sx.filter(Boolean)) : (sx ?? {});
   return ${wrappedJsx};
 }

--- a/template.cjs
+++ b/template.cjs
@@ -1,5 +1,6 @@
 const babelTemplate = require('@babel/template').smart;
 const {
+  cloneNode,
   identifier,
   jsxAttribute,
   jsxClosingElement,
@@ -24,6 +25,14 @@ const template = (
     preserveComments: true,
     syntacticPlaceholders: false,
   }).ast;
+  const wrappedSvg = cloneNode(jsx, true);
+  wrappedSvg.openingElement.attributes = [
+    ...wrappedSvg.openingElement.attributes,
+    jsxAttribute(
+      jsxIdentifier('style'),
+      jsxExpressionContainer(identifier('svgS'))
+    ),
+  ];
   const wrappedJsx = jsxElement(
     jsxOpeningElement(jsxIdentifier('div'), [
       jsxSpreadAttribute(identifier('props')),
@@ -47,7 +56,7 @@ const template = (
       ),
     ]),
     jsxClosingElement(jsxIdentifier('div')),
-    [jsx],
+    [wrappedSvg],
     false
   );
 
@@ -56,7 +65,8 @@ import type { CSSProperties, HTMLAttributes } from 'react';
 
 type IconCSSProperties = CSSProperties &
   Record<\`--\${string}\`, string | number | undefined>;
-type SxValue = IconCSSProperties | null | undefined | false;
+type IconSxObject = IconCSSProperties & { svg?: IconCSSProperties };
+type SxValue = IconSxObject | null | undefined | false;
 type SxProp = SxValue | SxValue[];
 type IconSize = CSSProperties['width'];
 
@@ -70,7 +80,9 @@ interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'style'> {
 ${interfaces}
 
 function ${componentName}({ sx, style, width, height, ...props }: Props) {
-  const s = Array.isArray(sx) ? Object.assign({}, ...sx.filter(Boolean)) : (sx ?? {});
+  const sxItems = (Array.isArray(sx) ? sx : [sx]).filter(Boolean) as IconSxObject[];
+  const s = Object.assign({}, ...sxItems.map(({ svg, ...root }) => root));
+  const svgS = Object.assign({}, ...sxItems.map(({ svg }) => svg).filter(Boolean));
   return ${wrappedJsx};
 }
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig({
       entry: files,
     },
     rollupOptions: {
-      external: ['@mui/material', 'react', 'react/jsx-runtime'],
+      external: ['react', 'react/jsx-runtime'],
       input: files,
       output: [
         {


### PR DESCRIPTION
## Summary
- remove the MUI Box-based icon wrapper and replace it with native DOM props plus internal sx/style merging
- drop the published @mui/material peer dependency from the icons package
- bump @growthx-club/icons to 3.0.0 because MUI-specific sx behavior is no longer supported

## Validation
- npm run convert-svg
- npm run build